### PR TITLE
Store processed health data in Firestore

### DIFF
--- a/InSite/InSiteData/DataManager.swift
+++ b/InSite/InSiteData/DataManager.swift
@@ -1,10 +1,26 @@
 import Foundation
 import HealthKit
+import FirebaseFirestore
+import FirebaseAuth
 
 class DataManager {
     static let shared = DataManager()
     private var healthStore: HealthStore?
     private let dispatchGroup = DispatchGroup()
+    private let isoFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return formatter
+    }()
+
+    private func isoString(from date: Date) -> String {
+        isoFormatter.string(from: date)
+    }
+
+    private func userCollection(_ name: String) -> CollectionReference? {
+        guard let uid = Auth.auth().currentUser?.uid else { return nil }
+        return Firestore.firestore().collection("users").document(uid).collection(name)
+    }
     
     private init() {
         healthStore = HealthStore()
@@ -99,42 +115,42 @@ class DataManager {
     
     private func processHourlyBgData(_ data: [HourlyBgData]) {
         print("Processed hourly blood glucose data")
-        // Process and save the hourly blood glucose data
+        uploadHourlyBgData(data)
     }
     
     private func processAvgBgData(_ data: [HourlyAvgBgData]) {
         print("Processed average blood glucose data")
-        // Process and save the average blood glucose data
+        uploadAverageBgData(data)
     }
     
     private func processHourlyBgPercentages(_ data: [HourlyBgPercentages]) {
         print("Processed hourly blood glucose percentages")
-        // Process and save the hourly blood glucose percentages data
+        uploadHourlyBgPercentages(data)
     }
     
     private func processHourlyHeartRateData(_ data: [Date: HourlyHeartRateData]) {
         print("Processed hourly heart rate data")
-        // Process and save the hourly heart rate data
+        uploadHourlyHeartRateData(data)
     }
     
     private func processDailyAverageHeartRateData(_ data: [DailyAverageHeartRateData]) {
         print("Processed daily average heart rate data")
-        // Process and save the daily average heart rate data
+        uploadDailyAverageHeartRateData(data)
     }
     
     private func processHourlyExerciseData(_ data: [Date: HourlyExerciseData]) {
         print("Processed hourly exercise data")
-        // Process and save the hourly exercise data
+        uploadHourlyExerciseData(data)
     }
-    
+
     private func processDailyAverageExerciseData(_ data: [Date: DailyAverageExerciseData]) {
         print("Processed daily average exercise data")
-        // Process and save the daily average exercise data
+        uploadDailyAverageExerciseData(data)
     }
     
     private func processMenstrualData(_ data: [Date: DailyMenstrualData]) {
         print("Processed menstrual data")
-        // Process and save the menstrual data
+        uploadMenstrualData(data)
     }
     
     private func processBodyMassData(_ data: [HourlyBodyMassData]) {
@@ -145,8 +161,8 @@ class DataManager {
             bodyMassDict[massData.hour] = massData.weight
         }
         
-        // Now you can save or process `bodyMassDict`
         print("Body mass data dictionary: \(bodyMassDict)")
+        uploadBodyMassData(data)
     }
 
     
@@ -157,24 +173,194 @@ class DataManager {
         for heartRateData in data {
             restingHeartRateDict[heartRateData.date] = heartRateData.restingHeartRate
         }
-        
+
         // Now you can save or process `restingHeartRateDict`
         print("Resting heart rate data dictionary: \(restingHeartRateDict)")
+        uploadRestingHeartRateData(data)
     }
 
     
     private func processSleepDurations(_ data: [Date: DailySleepDurations]) {
         print("Processed sleep durations")
-        // Process and save the sleep durations
+        uploadSleepDurations(data)
     }
-    
+
     private func processHourlyEnergyData(_ data: [Date: HourlyEnergyData]) {
         print("Processed hourly energy data")
-        // Process and save the hourly energy data
+        uploadHourlyEnergyData(data)
     }
-    
+
     private func processDailyAverageEnergyData(_ data: [DailyAverageEnergyData]) {
         print("Processed daily average energy data")
-        // Process and save the daily average energy data
+        uploadDailyAverageEnergyData(data)
+    }
+
+    // MARK: - Firebase Upload Helpers
+
+    private func uploadHourlyBgData(_ data: [HourlyBgData]) {
+        guard let collection = userCollection("blood_glucose") else { return }
+        for entry in data {
+            var dict: [String: Any] = [
+                "startDate": isoString(from: entry.startDate),
+                "endDate": isoString(from: entry.endDate),
+                "type": "hourly"
+            ]
+            if let start = entry.startBg { dict["startBg"] = start }
+            if let end = entry.endBg { dict["endBg"] = end }
+            collection.document("hourly-\(isoString(from: entry.startDate))").setData(dict)
+        }
+    }
+
+    private func uploadAverageBgData(_ data: [HourlyAvgBgData]) {
+        guard let collection = userCollection("blood_glucose") else { return }
+        for entry in data {
+            var dict: [String: Any] = [
+                "startDate": isoString(from: entry.startDate),
+                "endDate": isoString(from: entry.endDate),
+                "type": "average"
+            ]
+            if let avg = entry.averageBg { dict["averageBg"] = avg }
+            collection.document("average-\(isoString(from: entry.startDate))").setData(dict)
+        }
+    }
+
+    private func uploadHourlyBgPercentages(_ data: [HourlyBgPercentages]) {
+        guard let collection = userCollection("blood_glucose") else { return }
+        for entry in data {
+            let dict: [String: Any] = [
+                "startDate": isoString(from: entry.startDate),
+                "endDate": isoString(from: entry.endDate),
+                "percentLow": entry.percentLow,
+                "percentHigh": entry.percentHigh,
+                "type": "percent"
+            ]
+            collection.document("percent-\(isoString(from: entry.startDate))").setData(dict)
+        }
+    }
+
+    private func uploadHourlyHeartRateData(_ data: [Date: HourlyHeartRateData]) {
+        guard let collection = userCollection("heart_rate") else { return }
+        for (date, entry) in data {
+            let dict: [String: Any] = [
+                "hour": isoString(from: entry.hour),
+                "heartRate": entry.heartRate,
+                "type": "hourly"
+            ]
+            collection.document("hourly-\(isoString(from: date))").setData(dict)
+        }
+    }
+
+    private func uploadDailyAverageHeartRateData(_ data: [DailyAverageHeartRateData]) {
+        guard let collection = userCollection("heart_rate") else { return }
+        for entry in data {
+            let dict: [String: Any] = [
+                "date": isoString(from: entry.date),
+                "averageHeartRate": entry.averageHeartRate,
+                "type": "daily_average"
+            ]
+            collection.document("average-\(isoString(from: entry.date))").setData(dict)
+        }
+    }
+
+    private func uploadHourlyExerciseData(_ data: [Date: HourlyExerciseData]) {
+        guard let collection = userCollection("exercise") else { return }
+        for (date, entry) in data {
+            let dict: [String: Any] = [
+                "hour": isoString(from: entry.hour),
+                "moveMinutes": entry.moveMinutes,
+                "exerciseMinutes": entry.exerciseMinutes,
+                "totalMinutes": entry.totalMinutes,
+                "type": "hourly"
+            ]
+            collection.document("hourly-\(isoString(from: date))").setData(dict)
+        }
+    }
+
+    private func uploadDailyAverageExerciseData(_ data: [Date: DailyAverageExerciseData]) {
+        guard let collection = userCollection("exercise") else { return }
+        for (date, entry) in data {
+            let dict: [String: Any] = [
+                "date": isoString(from: entry.date),
+                "averageMoveMinutes": entry.averageMoveMinutes,
+                "averageExerciseMinutes": entry.averageExerciseMinutes,
+                "averageTotalMinutes": entry.averageTotalMinutes,
+                "type": "daily_average"
+            ]
+            collection.document("average-\(isoString(from: date))").setData(dict)
+        }
+    }
+
+    private func uploadMenstrualData(_ data: [Date: DailyMenstrualData]) {
+        guard let collection = userCollection("menstrual") else { return }
+        for (date, entry) in data {
+            let dict: [String: Any] = [
+                "date": isoString(from: entry.date),
+                "daysSincePeriodStart": entry.daysSincePeriodStart
+            ]
+            collection.document(isoString(from: date)).setData(dict)
+        }
+    }
+
+    private func uploadBodyMassData(_ data: [HourlyBodyMassData]) {
+        guard let collection = userCollection("body_mass") else { return }
+        for entry in data {
+            let dict: [String: Any] = [
+                "hour": isoString(from: entry.hour),
+                "weight": entry.weight
+            ]
+            collection.document(isoString(from: entry.hour)).setData(dict)
+        }
+    }
+
+    private func uploadRestingHeartRateData(_ data: [DailyRestingHeartRateData]) {
+        guard let collection = userCollection("resting_heart_rate") else { return }
+        for entry in data {
+            let dict: [String: Any] = [
+                "date": isoString(from: entry.date),
+                "restingHeartRate": entry.restingHeartRate
+            ]
+            collection.document(isoString(from: entry.date)).setData(dict)
+        }
+    }
+
+    private func uploadSleepDurations(_ data: [Date: DailySleepDurations]) {
+        guard let collection = userCollection("sleep") else { return }
+        for (date, entry) in data {
+            let dict: [String: Any] = [
+                "date": isoString(from: entry.date),
+                "awake": entry.awake,
+                "asleepCore": entry.asleepCore,
+                "asleepDeep": entry.asleepDeep,
+                "asleepREM": entry.asleepREM,
+                "asleepUnspecified": entry.asleepUnspecified
+            ]
+            collection.document(isoString(from: date)).setData(dict)
+        }
+    }
+
+    private func uploadHourlyEnergyData(_ data: [Date: HourlyEnergyData]) {
+        guard let collection = userCollection("energy") else { return }
+        for (date, entry) in data {
+            let dict: [String: Any] = [
+                "hour": isoString(from: entry.hour),
+                "basalEnergy": entry.basalEnergy,
+                "activeEnergy": entry.activeEnergy,
+                "totalEnergy": entry.totalEnergy,
+                "type": "hourly"
+            ]
+            collection.document("hourly-\(isoString(from: date))").setData(dict)
+        }
+    }
+
+    private func uploadDailyAverageEnergyData(_ data: [DailyAverageEnergyData]) {
+        guard let collection = userCollection("energy") else { return }
+        for entry in data {
+            let dict: [String: Any] = [
+                "date": isoString(from: entry.date),
+                "averageActiveEnergy": entry.averageActiveEnergy,
+                "type": "daily_average"
+            ]
+            collection.document("average-\(isoString(from: entry.date))").setData(dict)
+        }
     }
 }


### PR DESCRIPTION
## Summary
- integrate Firebase Auth/Firestore in `DataManager`
- upload processed health metrics (blood glucose, heart rate, etc.) to user collections
- helper to format dates to ISO8601 strings

## Testing
- `swift test -l` *(fails: Package.swift missing)*

------
https://chatgpt.com/codex/tasks/task_e_6887eb8d9940832680a12c31e88c1831