### PR TITLE
Log therapy profile snapshots and tag hourly uploads

### DIFF
--- a/InSite/Firestore/TherapySettingsLogManager.swift
+++ b/InSite/Firestore/TherapySettingsLogManager.swift
@@ -1,0 +1,50 @@
+import Foundation
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+import FirebaseAuth
+
+struct TherapySnapshot: Codable, Identifiable {
+    @DocumentID var id: String?
+    var timestamp: Date
+    var profileId: String
+    var profileName: String
+    var hourRanges: [HourRange]
+}
+
+final class TherapySettingsLogManager {
+    static let shared = TherapySettingsLogManager()
+    private init() {}
+
+    private func logCollection(for uid: String) -> CollectionReference {
+        Firestore.firestore().collection("users").document(uid).collection("therapy_settings_log")
+    }
+
+    private var cache: [TherapySnapshot] = []
+
+    func logTherapySettingsChange(profile: DiabeticProfile, timestamp: Date = Date()) async throws {
+        guard let uid = Auth.auth().currentUser?.uid else { return }
+        let snapshot = TherapySnapshot(timestamp: timestamp, profileId: profile.id, profileName: profile.name, hourRanges: profile.hourRanges)
+        try logCollection(for: uid).addDocument(from: snapshot)
+        cache.append(snapshot)
+        cache.sort { $0.timestamp < $1.timestamp }
+    }
+
+    func getActiveTherapyProfile(at date: Date) async throws -> TherapySnapshot? {
+        if let cached = cache.last(where: { $0.timestamp <= date }) {
+            return cached
+        }
+        guard let uid = Auth.auth().currentUser?.uid else { return nil }
+        let query = logCollection(for: uid)
+            .order(by: "timestamp", descending: true)
+            .whereField("timestamp", isLessThanOrEqualTo: date)
+            .limit(to: 1)
+        let snapshot = try await query.getDocuments().documents.first
+        if let snapshot = snapshot {
+            let snap = try snapshot.data(as: TherapySnapshot.self)
+            cache.append(snap)
+            cache.sort { $0.timestamp < $1.timestamp }
+            return snap
+        }
+        return nil
+    }
+}

--- a/InSite/InSiteData/DataManager.swift
+++ b/InSite/InSiteData/DataManager.swift
@@ -140,22 +140,50 @@ class DataManager {
     
     private func processHourlyBgData(_ data: [HourlyBgData]) {
         print("Processed hourly blood glucose data")
-        uploader.uploadHourlyBgData(data)
+        Task {
+            var enriched: [(HourlyBgData, String?)] = []
+            for entry in data {
+                let profile = try? await TherapySettingsLogManager.shared.getActiveTherapyProfile(at: entry.startDate)
+                enriched.append((entry, profile?.profileId))
+            }
+            uploader.uploadHourlyBgData(enriched)
+        }
     }
-    
+
     private func processAvgBgData(_ data: [HourlyAvgBgData]) {
         print("Processed average blood glucose data")
-        uploader.uploadAverageBgData(data)
+        Task {
+            var enriched: [(HourlyAvgBgData, String?)] = []
+            for entry in data {
+                let profile = try? await TherapySettingsLogManager.shared.getActiveTherapyProfile(at: entry.startDate)
+                enriched.append((entry, profile?.profileId))
+            }
+            uploader.uploadAverageBgData(enriched)
+        }
     }
-    
+
     private func processHourlyBgPercentages(_ data: [HourlyBgPercentages]) {
         print("Processed hourly blood glucose percentages")
-        uploader.uploadHourlyBgPercentages(data)
+        Task {
+            var enriched: [(HourlyBgPercentages, String?)] = []
+            for entry in data {
+                let profile = try? await TherapySettingsLogManager.shared.getActiveTherapyProfile(at: entry.startDate)
+                enriched.append((entry, profile?.profileId))
+            }
+            uploader.uploadHourlyBgPercentages(enriched)
+        }
     }
-    
+
     private func processHourlyHeartRateData(_ data: [Date: HourlyHeartRateData]) {
         print("Processed hourly heart rate data")
-        uploader.uploadHourlyHeartRateData(data)
+        Task {
+            var enriched: [Date: (HourlyHeartRateData, String?)] = [:]
+            for (date, entry) in data {
+                let profile = try? await TherapySettingsLogManager.shared.getActiveTherapyProfile(at: date)
+                enriched[date] = (entry, profile?.profileId)
+            }
+            uploader.uploadHourlyHeartRateData(enriched)
+        }
     }
     
     private func processDailyAverageHeartRateData(_ data: [DailyAverageHeartRateData]) {
@@ -165,7 +193,14 @@ class DataManager {
     
     private func processHourlyExerciseData(_ data: [Date: HourlyExerciseData]) {
         print("Processed hourly exercise data")
-        uploader.uploadHourlyExerciseData(data)
+        Task {
+            var enriched: [Date: (HourlyExerciseData, String?)] = [:]
+            for (date, entry) in data {
+                let profile = try? await TherapySettingsLogManager.shared.getActiveTherapyProfile(at: date)
+                enriched[date] = (entry, profile?.profileId)
+            }
+            uploader.uploadHourlyExerciseData(enriched)
+        }
     }
 
     private func processDailyAverageExerciseData(_ data: [Date: DailyAverageExerciseData]) {
@@ -180,14 +215,19 @@ class DataManager {
     
     private func processBodyMassData(_ data: [HourlyBodyMassData]) {
         print("Processed body mass data")
-        
+
         var bodyMassDict = [Date: Double]()
-        for massData in data {
-            bodyMassDict[massData.hour] = massData.weight
+        Task {
+            var enriched: [(HourlyBodyMassData, String?)] = []
+            for massData in data {
+                bodyMassDict[massData.hour] = massData.weight
+                let profile = try? await TherapySettingsLogManager.shared.getActiveTherapyProfile(at: massData.hour)
+                enriched.append((massData, profile?.profileId))
+            }
+
+            print("Body mass data dictionary: \(bodyMassDict)")
+            uploader.uploadBodyMassData(enriched)
         }
-        
-        print("Body mass data dictionary: \(bodyMassDict)")
-        uploader.uploadBodyMassData(data)
     }
 
     
@@ -212,7 +252,14 @@ class DataManager {
 
     private func processHourlyEnergyData(_ data: [Date: HourlyEnergyData]) {
         print("Processed hourly energy data")
-        uploader.uploadHourlyEnergyData(data)
+        Task {
+            var enriched: [Date: (HourlyEnergyData, String?)] = [:]
+            for (date, entry) in data {
+                let profile = try? await TherapySettingsLogManager.shared.getActiveTherapyProfile(at: date)
+                enriched[date] = (entry, profile?.profileId)
+            }
+            uploader.uploadHourlyEnergyData(enriched)
+        }
     }
 
     private func processDailyAverageEnergyData(_ data: [DailyAverageEnergyData]) {

--- a/InSite/InSiteData/HealthDataUploader.swift
+++ b/InSite/InSiteData/HealthDataUploader.swift
@@ -28,10 +28,10 @@ class HealthDataUploader {
         }
     }
 
-    func uploadHourlyBgData(_ data: [HourlyBgData]) {
+    func uploadHourlyBgData(_ data: [(HourlyBgData, String?)]) {
         guard let collection = userCollection("blood_glucose") else { return }
         let batch = Firestore.firestore().batch()
-        for entry in data {
+        for (entry, profileId) in data {
             var dict: [String: Any] = [
                 "startDate": isoString(from: entry.startDate),
                 "endDate": isoString(from: entry.endDate),
@@ -39,51 +39,56 @@ class HealthDataUploader {
             ]
             if let start = entry.startBg { dict["startBg"] = start }
             if let end = entry.endBg { dict["endBg"] = end }
+            if let profileId = profileId { dict["therapyProfileId"] = profileId }
             batch.setData(dict, forDocument: collection.document("hourly-\(isoString(from: entry.startDate))"))
         }
         commit(batch, label: "hourly BG")
     }
 
-    func uploadAverageBgData(_ data: [HourlyAvgBgData]) {
+    func uploadAverageBgData(_ data: [(HourlyAvgBgData, String?)]) {
         guard let collection = userCollection("blood_glucose") else { return }
         let batch = Firestore.firestore().batch()
-        for entry in data {
+        for (entry, profileId) in data {
             var dict: [String: Any] = [
                 "startDate": isoString(from: entry.startDate),
                 "endDate": isoString(from: entry.endDate),
                 "type": "average"
             ]
             if let avg = entry.averageBg { dict["averageBg"] = avg }
+            if let profileId = profileId { dict["therapyProfileId"] = profileId }
             batch.setData(dict, forDocument: collection.document("average-\(isoString(from: entry.startDate))"))
         }
         commit(batch, label: "avg BG")
     }
 
-    func uploadHourlyBgPercentages(_ data: [HourlyBgPercentages]) {
+    func uploadHourlyBgPercentages(_ data: [(HourlyBgPercentages, String?)]) {
         guard let collection = userCollection("blood_glucose") else { return }
         let batch = Firestore.firestore().batch()
-        for entry in data {
-            let dict: [String: Any] = [
+        for (entry, profileId) in data {
+            var dict: [String: Any] = [
                 "startDate": isoString(from: entry.startDate),
                 "endDate": isoString(from: entry.endDate),
                 "percentLow": entry.percentLow,
                 "percentHigh": entry.percentHigh,
                 "type": "percent"
             ]
+            if let profileId = profileId { dict["therapyProfileId"] = profileId }
             batch.setData(dict, forDocument: collection.document("percent-\(isoString(from: entry.startDate))"))
         }
         commit(batch, label: "bg percent")
     }
 
-    func uploadHourlyHeartRateData(_ data: [Date: HourlyHeartRateData]) {
+    func uploadHourlyHeartRateData(_ data: [Date: (HourlyHeartRateData, String?)]) {
         guard let collection = userCollection("heart_rate") else { return }
         let batch = Firestore.firestore().batch()
-        for (date, entry) in data {
-            let dict: [String: Any] = [
+        for (date, tuple) in data {
+            let (entry, profileId) = tuple
+            var dict: [String: Any] = [
                 "hour": isoString(from: entry.hour),
                 "heartRate": entry.heartRate,
                 "type": "hourly"
             ]
+            if let profileId = profileId { dict["therapyProfileId"] = profileId }
             batch.setData(dict, forDocument: collection.document("hourly-\(isoString(from: date))"))
         }
         commit(batch, label: "hourly HR")
@@ -103,17 +108,19 @@ class HealthDataUploader {
         commit(batch, label: "avg HR")
     }
 
-    func uploadHourlyExerciseData(_ data: [Date: HourlyExerciseData]) {
+    func uploadHourlyExerciseData(_ data: [Date: (HourlyExerciseData, String?)]) {
         guard let collection = userCollection("exercise") else { return }
         let batch = Firestore.firestore().batch()
-        for (date, entry) in data {
-            let dict: [String: Any] = [
+        for (date, tuple) in data {
+            let (entry, profileId) = tuple
+            var dict: [String: Any] = [
                 "hour": isoString(from: entry.hour),
                 "moveMinutes": entry.moveMinutes,
                 "exerciseMinutes": entry.exerciseMinutes,
                 "totalMinutes": entry.totalMinutes,
                 "type": "hourly"
             ]
+            if let profileId = profileId { dict["therapyProfileId"] = profileId }
             batch.setData(dict, forDocument: collection.document("hourly-\(isoString(from: date))"))
         }
         commit(batch, label: "hourly exercise")
@@ -148,14 +155,15 @@ class HealthDataUploader {
         commit(batch, label: "menstrual")
     }
 
-    func uploadBodyMassData(_ data: [HourlyBodyMassData]) {
+    func uploadBodyMassData(_ data: [(HourlyBodyMassData, String?)]) {
         guard let collection = userCollection("body_mass") else { return }
         let batch = Firestore.firestore().batch()
-        for entry in data {
-            let dict: [String: Any] = [
+        for (entry, profileId) in data {
+            var dict: [String: Any] = [
                 "hour": isoString(from: entry.hour),
                 "weight": entry.weight
             ]
+            if let profileId = profileId { dict["therapyProfileId"] = profileId }
             batch.setData(dict, forDocument: collection.document(isoString(from: entry.hour)))
         }
         commit(batch, label: "body mass")
@@ -191,17 +199,19 @@ class HealthDataUploader {
         commit(batch, label: "sleep")
     }
 
-    func uploadHourlyEnergyData(_ data: [Date: HourlyEnergyData]) {
+    func uploadHourlyEnergyData(_ data: [Date: (HourlyEnergyData, String?)]) {
         guard let collection = userCollection("energy") else { return }
         let batch = Firestore.firestore().batch()
-        for (date, entry) in data {
-            let dict: [String: Any] = [
+        for (date, tuple) in data {
+            let (entry, profileId) = tuple
+            var dict: [String: Any] = [
                 "hour": isoString(from: entry.hour),
                 "basalEnergy": entry.basalEnergy,
                 "activeEnergy": entry.activeEnergy,
                 "totalEnergy": entry.totalEnergy,
                 "type": "hourly"
             ]
+            if let profileId = profileId { dict["therapyProfileId"] = profileId }
             batch.setData(dict, forDocument: collection.document("hourly-\(isoString(from: date))"))
         }
         commit(batch, label: "energy")

--- a/InSite/InSiteData/MockHealthDataSeeder.swift
+++ b/InSite/InSiteData/MockHealthDataSeeder.swift
@@ -97,18 +97,18 @@ struct MockHealthDataSeeder {
             dailyAvgEnergy.append(DailyAverageEnergyData(date: dayStart, averageActiveEnergy: avgActiveEnergy))
         }
 
-        uploader.uploadHourlyBgData(hourlyBgData)
-        uploader.uploadAverageBgData(avgBgData)
-        uploader.uploadHourlyBgPercentages(bgPercentages)
-        uploader.uploadHourlyHeartRateData(hourlyHeartRates)
+        uploader.uploadHourlyBgData(hourlyBgData.map { ($0, nil) })
+        uploader.uploadAverageBgData(avgBgData.map { ($0, nil) })
+        uploader.uploadHourlyBgPercentages(bgPercentages.map { ($0, nil) })
+        uploader.uploadHourlyHeartRateData(hourlyHeartRates.mapValues { ($0, nil) })
         uploader.uploadDailyAverageHeartRateData(dailyAvgHeartRates)
-        uploader.uploadHourlyExerciseData(hourlyExercise)
+        uploader.uploadHourlyExerciseData(hourlyExercise.mapValues { ($0, nil) })
         uploader.uploadDailyAverageExerciseData(dailyAvgExercise)
         uploader.uploadMenstrualData(menstrualData)
-        uploader.uploadBodyMassData(bodyMassData)
+        uploader.uploadBodyMassData(bodyMassData.map { ($0, nil) })
         uploader.uploadRestingHeartRateData(restingHeartRates)
         uploader.uploadSleepDurations(sleepDurations)
-        uploader.uploadHourlyEnergyData(hourlyEnergy)
+        uploader.uploadHourlyEnergyData(hourlyEnergy.mapValues { ($0, nil) })
         uploader.uploadDailyAverageEnergyData(dailyAvgEnergy)
     }
 }

--- a/InSite/InSiteUI/TherapySettings.swift
+++ b/InSite/InSiteUI/TherapySettings.swift
@@ -4,7 +4,8 @@ import UIKit
 //Hold down on long press
 
 
-struct DiabeticProfile: Codable {
+struct DiabeticProfile: Codable, Identifiable {
+    var id: String = UUID().uuidString
     var name: String
     var hourRanges: [HourRange] // Assuming HourRange is defined to group hours
 }
@@ -78,7 +79,13 @@ struct TherapySettings: View {
                                             }
                                             .contentShape(Rectangle())
                                             .onTapGesture {
-                                                self.selectedProfileIndex = index
+                                                if self.selectedProfileIndex != index {
+                                                    self.selectedProfileIndex = index
+                                                    let profile = self.profiles[index]
+                                                    Task {
+                                                        try? await TherapySettingsLogManager.shared.logTherapySettingsChange(profile: profile, timestamp: Date())
+                                                    }
+                                                }
                                             }
                                         }
                                         .onDelete(perform: deleteProfile)


### PR DESCRIPTION
## Summary
- log therapy settings changes to Firestore and retrieve snapshots by timestamp
- tag hourly health data uploads with active therapy profile
- persist profile IDs and log selection changes in Therapy Settings UI

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_6896307d81548326be6a25ce84ecc0a9