### PR TITLE
Make UI layouts responsive

### DIFF
--- a/InSite/Core/Authentication/AuthView.swift
+++ b/InSite/Core/Authentication/AuthView.swift
@@ -47,39 +47,38 @@ struct AuthView: View {
     
     
     var body: some View {
-        VStack {
-            Button(action: {
-                Task {
-                    do {
-                        try await viewModel.signInAnonymous()
-                        showSignInView = false
-                    } catch {
-                        print(error)
+        GeometryReader { geometry in
+            VStack {
+                Button(action: {
+                    Task {
+                        do {
+                            try await viewModel.signInAnonymous()
+                            showSignInView = false
+                        } catch {
+                            print(error)
+                        }
                     }
+                }) {
+                    Text("Sign in Anonymously")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(height: geometry.size.height * 0.07)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.orange)
+                        .cornerRadius(geometry.size.height * 0.02)
                 }
-            }) {
-                Text("Sign in Anonymously")
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(height:55)
-                    .frame(maxWidth: .infinity)
-                    .background(Color.orange)
-                    .cornerRadius(10)
-            }
 
-            
-            
-            NavigationLink {
-                SignInEmailView(showSignInView: $showSignInView)
-            } label: {
-                Text("Sign in with email")
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(height:55)
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-                    .cornerRadius(10)
-            }
+                NavigationLink {
+                    SignInEmailView(showSignInView: $showSignInView)
+                } label: {
+                    Text("Sign in with email")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(height: geometry.size.height * 0.07)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.blue)
+                        .cornerRadius(geometry.size.height * 0.02)
+                }
             
             GoogleSignInButton(viewModel: GoogleSignInButtonViewModel(scheme: .dark,style: .wide,state: .normal))  {
                 Task {
@@ -92,31 +91,32 @@ struct AuthView: View {
                 }
                 
             }
-            Button(action: {
-                Task {
-                    do {
-                        try await viewModel.signInApple()
+                Button(action: {
+                    Task {
+                        do {
+                            try await viewModel.signInApple()
 //                        showSignInView = false
-                    } catch {
-                        print(error)
+                        } catch {
+                            print(error)
+                        }
+                    }
+
+
+                }, label: {
+                    SignInWithAppleButtonViewRepresentable(type: .default, style: .black)
+
+                })
+                .frame(height: geometry.size.height * 0.07)
+                .onChange(of: viewModel.didSignInWithApple) { newValue in
+                    if newValue {
+                        showSignInView = false
                     }
                 }
-                
-                
-            }, label: {
-                SignInWithAppleButtonViewRepresentable(type: .default, style: .black)
-                
-            })
-            .frame(height:55)
-            .onChange(of: viewModel.didSignInWithApple) { newValue in
-                if newValue {
-                    showSignInView = false
-                }
+                Spacer()
             }
-            Spacer()
+            .padding()
+            .navigationTitle("Sign In")
         }
-        .padding()
-        .navigationTitle("Sign In")
     }
 }
 

--- a/InSite/Core/Subviews/SignInEmailView.swift
+++ b/InSite/Core/Subviews/SignInEmailView.swift
@@ -11,46 +11,48 @@ struct SignInEmailView: View {
     @StateObject private var viewModel = SignInEmailViewModel()
     @Binding var showSignInView: Bool
     var body: some View {
-        VStack {
-            TextField("Email...",text:$viewModel.email)
-                .padding()
-                .background(Color.gray.opacity(0.4))
-                .cornerRadius(10)
-            SecureField("Password...",text:$viewModel.password)
-                .padding()
-                .background(Color.gray.opacity(0.4))
-                .cornerRadius(10)
-            Button {
-                Task {
-                    do {
-                        try await viewModel.signUp()
-                        showSignInView = false
-                        return
-                    } catch {
-                        print(error)
+        GeometryReader { geometry in
+            VStack {
+                TextField("Email...",text:$viewModel.email)
+                    .padding()
+                    .background(Color.gray.opacity(0.4))
+                    .cornerRadius(geometry.size.height * 0.02)
+                SecureField("Password...",text:$viewModel.password)
+                    .padding()
+                    .background(Color.gray.opacity(0.4))
+                    .cornerRadius(geometry.size.height * 0.02)
+                Button {
+                    Task {
+                        do {
+                            try await viewModel.signUp()
+                            showSignInView = false
+                            return
+                        } catch {
+                            print(error)
+                        }
+                        do {
+                            try await viewModel.signIn()
+                            showSignInView = false
+                            return
+                        } catch {
+                            print(error)
+                        }
                     }
-                    do {
-                        try await viewModel.signIn()
-                        showSignInView = false
-                        return
-                    } catch {
-                        print(error)
-                    }
+
+                } label: {
+                    Text("Sign in")
+                        .font(.headline)
+                        .foregroundColor(.white)
+                        .frame(height: geometry.size.height * 0.07)
+                        .frame(maxWidth: .infinity)
+                        .background(Color.blue)
+                        .cornerRadius(geometry.size.height * 0.02)
                 }
-             
-            } label: {
-                Text("Sign in")
-                    .font(.headline)
-                    .foregroundColor(.white)
-                    .frame(height:55)
-                    .frame(maxWidth: .infinity)
-                    .background(Color.blue)
-                    .cornerRadius(10)
+                Spacer()
             }
-            Spacer()
+            .padding()
+            .navigationTitle("Sign in with email")
         }
-        .padding()
-        .navigationTitle("Sign in with email")
     }
 }
 

--- a/InSite/InSiteUI/HomeScreen.swift
+++ b/InSite/InSiteUI/HomeScreen.swift
@@ -26,116 +26,128 @@ struct HomeScreen: View {
     @Binding var showSignInView: Bool
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color(UIColor.six).ignoresSafeArea()
-                VStack(spacing: 20) {
-                    Text("InSite")
-                        .font(.title)
-                        .fontWeight(.light)
-                        .padding(20)
-                        .background(RoundedRectangle(cornerRadius: 20).fill(pastelBlue).shadow(color: .gray, radius: 0, x: 0, y: 2))
-                        .foregroundColor(Color.white)
-                        .frame(width: 250, height: 100)
-                    
-                    Image("BearBlue")
-                        .resizable()
-                        .scaledToFill()
-                        .frame(width: 300, height: 300)
-                        .clipShape(Circle())
-                        .overlay(
-                            Circle().stroke(pastelBlue, lineWidth: 4).shadow(color: Color.brown, radius: 2, x: 0, y: 0).clipShape(Circle())
-                        )
-                    
-                    HStack(spacing: 5) {
-                        Spacer()
-                        
-                        VStack {
-                            NavigationLink(destination: SiteChangeUI()) {
-                                Image(systemName: "arrow.right.circle.fill")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 40, height: 40)
-                                    .foregroundColor(.white)
-                                    .background(pastelBlue)
-                                    .cornerRadius(20)
-                                    .padding()
-                                    .shadow(color: .gray, radius: 0, x: 0, y: 2)
-                            }
-                            .frame(width: 70, height: 70)
-                            Text("Change Site").fontWeight(.semibold).foregroundColor(.white)
-                        }
-                        .padding(.horizontal, 10)
-                        
-                        VStack {
-                            Button(action: {
-                                DataManager.shared.syncHealthData {
-                                    print("Health data synchronized")
+        GeometryReader { geometry in
+            NavigationStack {
+                ZStack {
+                    Color(UIColor.six).ignoresSafeArea()
+                    VStack(spacing: geometry.size.height * 0.03) {
+                        Text("InSite")
+                            .font(.title)
+                            .fontWeight(.light)
+                            .padding(geometry.size.height * 0.025)
+                            .background(
+                                RoundedRectangle(cornerRadius: geometry.size.height * 0.03)
+                                    .fill(pastelBlue)
+                                    .shadow(color: .gray, radius: geometry.size.height * 0.002, x: 0, y: geometry.size.height * 0.002)
+                            )
+                            .foregroundColor(Color.white)
+                            .frame(width: geometry.size.width * 0.6, height: geometry.size.height * 0.12)
+
+                        Image("BearBlue")
+                            .resizable()
+                            .scaledToFill()
+                            .frame(width: geometry.size.width * 0.7, height: geometry.size.width * 0.7)
+                            .clipShape(Circle())
+                            .overlay(
+                                Circle()
+                                    .stroke(pastelBlue, lineWidth: geometry.size.width * 0.01)
+                                    .shadow(color: Color.brown, radius: geometry.size.width * 0.005, x: 0, y: 0)
+                                    .clipShape(Circle())
+                            )
+
+                        HStack(spacing: geometry.size.width * 0.015) {
+                            Spacer()
+
+                            VStack {
+                                NavigationLink(destination: SiteChangeUI()) {
+                                    Image(systemName: "arrow.right.circle.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: geometry.size.width * 0.1, height: geometry.size.width * 0.1)
+                                        .foregroundColor(.white)
+                                        .background(pastelBlue)
+                                        .cornerRadius(geometry.size.width * 0.05)
+                                        .padding(geometry.size.width * 0.02)
+                                        .shadow(color: .gray, radius: geometry.size.width * 0.002, x: 0, y: geometry.size.width * 0.002)
                                 }
-                                print("button pressed")
-                            }) {
-                                Image(systemName: "arrow.right.circle.fill")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 40, height: 40)
-                                    .foregroundColor(.white)
-                                    .background(Color.blue)
-                                    .cornerRadius(20)
-                                    .padding()
-                                    .shadow(color: .gray, radius: 0, x: 0, y: 2)
+                                .frame(width: geometry.size.width * 0.18, height: geometry.size.width * 0.18)
+                                Text("Change Site").fontWeight(.semibold).foregroundColor(.white)
                             }
-                            .frame(width: 70, height: 70)
-                            Text("Data").fontWeight(.semibold).foregroundColor(.white)
-                        }
-                        .cornerRadius(10)
-                        .padding()
-                        
-                        VStack {
-                            NavigationLink(destination: SettingsView(showSignInView: $showSignInView)) {
-                                Image(systemName: "arrow.right.circle.fill")
-                                    .resizable()
-                                    .aspectRatio(contentMode: .fit)
-                                    .frame(width: 40, height: 40)
-                                    .foregroundColor(.white)
-                                    .background(pastelBlue)
-                                    .cornerRadius(20)
-                                    .padding()
-                                    .shadow(color: .gray, radius: 0, x: 0, y: 2)
+                            .padding(.horizontal, geometry.size.width * 0.03)
+
+                            VStack {
+                                Button(action: {
+                                    DataManager.shared.syncHealthData {
+                                        print("Health data synchronized")
+                                    }
+                                    print("button pressed")
+                                }) {
+                                    Image(systemName: "arrow.right.circle.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: geometry.size.width * 0.1, height: geometry.size.width * 0.1)
+                                        .foregroundColor(.white)
+                                        .background(Color.blue)
+                                        .cornerRadius(geometry.size.width * 0.05)
+                                        .padding(geometry.size.width * 0.02)
+                                        .shadow(color: .gray, radius: geometry.size.width * 0.002, x: 0, y: geometry.size.width * 0.002)
+                                }
+                                .frame(width: geometry.size.width * 0.18, height: geometry.size.width * 0.18)
+                                Text("Data").fontWeight(.semibold).foregroundColor(.white)
                             }
-                            .frame(width: 70, height: 70)
-                            Text("Account Settings").fontWeight(.semibold).foregroundColor(.white)
+                            .cornerRadius(geometry.size.width * 0.03)
+                            .padding(geometry.size.width * 0.02)
+
+                            VStack {
+                                NavigationLink(destination: SettingsView(showSignInView: $showSignInView)) {
+                                    Image(systemName: "arrow.right.circle.fill")
+                                        .resizable()
+                                        .aspectRatio(contentMode: .fit)
+                                        .frame(width: geometry.size.width * 0.1, height: geometry.size.width * 0.1)
+                                        .foregroundColor(.white)
+                                        .background(pastelBlue)
+                                        .cornerRadius(geometry.size.width * 0.05)
+                                        .padding(geometry.size.width * 0.02)
+                                        .shadow(color: .gray, radius: geometry.size.width * 0.002, x: 0, y: geometry.size.width * 0.002)
+                                }
+                                .frame(width: geometry.size.width * 0.18, height: geometry.size.width * 0.18)
+                                Text("Account Settings").fontWeight(.semibold).foregroundColor(.white)
+                            }
+                            .padding(.horizontal, geometry.size.width * 0.03)
+
+                            Spacer()
                         }
-                        .padding(.horizontal, 10)
-                        
+
                         Spacer()
+                        Rectangle()
+                            .foregroundColor(backgroundColor2)
+                            .edgesIgnoringSafeArea(.bottom)
+                            .frame(height: geometry.size.height * 0.05)
                     }
-                    
-                    Spacer()
-                    Rectangle().foregroundColor(backgroundColor2).edgesIgnoringSafeArea(.bottom).frame(height: 40)
+                }
+                .toolbar {
+                    ToolbarItemGroup(placement: .bottomBar) {
+                        NavigationLink(destination: TherapySettings()) {
+                            Text("Therapy Settings")
+                        }
+                        .fontWeight(.semibold)
+                        .frame(width: geometry.size.width * 0.4, height: geometry.size.height * 0.07)
+                        .padding()
+                        .foregroundColor(Color.white)
+                        .background(pastelBlue)
+                        .cornerRadius(geometry.size.height * 0.04)
+                        .padding(.horizontal, geometry.size.width * 0.05)
+                        .shadow(color: .gray, radius: geometry.size.width * 0.002, x: 0, y: geometry.size.width * 0.002)
+                    }
                 }
             }
-            .toolbar {
-                ToolbarItemGroup(placement: .bottomBar) {
-                    NavigationLink(destination: TherapySettings()) {
-                        Text("Therapy Settings")
+            .onAppear {
+                DataManager.shared.requestAuthorization { success in
+                    if success {
+                        print("Authorization granted")
+                    } else {
+                        print("Authorization denied")
                     }
-                    .fontWeight(.semibold)
-                    .frame(width: 150, height: 50)
-                    .padding()
-                    .foregroundColor(Color.white)
-                    .background(pastelBlue)
-                    .cornerRadius(40)
-                    .padding(.horizontal, 20)
-                    .shadow(color: .gray, radius: 0, x: 0, y: 2)
-                }
-            }
-        }
-        .onAppear {
-            DataManager.shared.requestAuthorization { success in
-                if success {
-                    print("Authorization granted")
-                } else {
-                    print("Authorization denied")
                 }
             }
         }

--- a/InSite/InSiteUI/SiteChangeUI.swift
+++ b/InSite/InSiteUI/SiteChangeUI.swift
@@ -30,7 +30,7 @@ struct CustomSwiftButton: View {
             .foregroundColor(textColor)
             .cornerRadius(geometry.size.width * 0.4)
             .font(.subheadline)
-            .shadow(radius: 4)
+            .shadow(radius: geometry.size.width * 0.05)
         }
     }
 }
@@ -84,8 +84,8 @@ struct SiteChangeUI: View {
                         .scaledToFill()
                         .frame(width: geometry.size.width * 0.8, height: geometry.size.height * 0.35)
                         .clipped()
-                        .cornerRadius(50)
-                        .shadow(radius: 20)
+                        .cornerRadius(geometry.size.width * 0.125)
+                        .shadow(radius: geometry.size.width * 0.05)
                     
                     
                     VStack(spacing: geometry.size.height * 0.04) {

--- a/InSite/InSiteUI/TherapySettings.swift
+++ b/InSite/InSiteUI/TherapySettings.swift
@@ -66,7 +66,8 @@ struct TherapySettings: View {
 
     var body: some View {
         NavigationView {
-            Form {
+            GeometryReader { geometry in
+                Form {
                 Section(header: Text("Profiles")) {
                                     List {
                                         ForEach(profiles.indices, id: \.self) { index in
@@ -196,7 +197,8 @@ struct HourRangeView: View {
     
     var body: some View {
         NavigationView {
-            Form {
+            GeometryReader { geometry in
+                Form {
                 Section {
                     Picker("Start Hour", selection: $startHour) {
                             ForEach(0..<24, id: \.self) { hour in
@@ -211,27 +213,31 @@ struct HourRangeView: View {
                 }
                 
                 Section {
-                    HStack(spacing: 10) {
+                    HStack(spacing: geometry.size.width * 0.02) {
                         Text("Carb Ratio: ")
-                        TextField("Carb Ratio", value: $carbRatio, formatter: NumberFormatter())}
-                    HStack(spacing: 10) {
+                        TextField("Carb Ratio", value: $carbRatio, formatter: NumberFormatter())
+                    }
+                    HStack(spacing: geometry.size.width * 0.02) {
                         Text("Basal Rate: ")
-                        TextField("Basal Rate", value: $basalRate, formatter: basalRateFormatter)}
-                    HStack(spacing: 10) {
+                        TextField("Basal Rate", value: $basalRate, formatter: basalRateFormatter)
+                    }
+                    HStack(spacing: geometry.size.width * 0.02) {
                         Text("Insulin Sensitivity: ")
-                        TextField("Insulin Sensitivity", value: $insulinSensitivity, formatter: NumberFormatter())}
-                }
-                
-                Button("Add Range") {
-                                    let newHourRange = HourRange(startHour: startHour, endHour: endHour, carbRatio: carbRatio, basalRate: basalRate, insulinSensitivity: insulinSensitivity)
-                                    profile.hourRanges.append(newHourRange)
-                                    self.presentationMode.wrappedValue.dismiss() // Dismiss the modal view
-                                }
-                            }
-                            .navigationBarTitle("Add Hour Range")
-                        }
+                        TextField("Insulin Sensitivity", value: $insulinSensitivity, formatter: NumberFormatter())
                     }
                 }
+
+                Button("Add Range") {
+                    let newHourRange = HourRange(startHour: startHour, endHour: endHour, carbRatio: carbRatio, basalRate: basalRate, insulinSensitivity: insulinSensitivity)
+                    profile.hourRanges.append(newHourRange)
+                    self.presentationMode.wrappedValue.dismiss() // Dismiss the modal view
+                }
+                .padding(.vertical, geometry.size.height * 0.01)
+            }
+            .navigationBarTitle("Add Hour Range")
+        }
+    }
+}
 
 struct ContentViewPreviews: PreviewProvider {
     static var previews: some View {


### PR DESCRIPTION
## Summary
- make HomeScreen layout scale with screen geometry
- adjust SiteChangeUI button and image styling responsively
- remove fixed spacing in TherapySettings forms
- compute auth and email sign-in button sizes from available space

## Testing
- `swift test` *(fails: Could not find Package.swift in this directory or any of its parent directories.)*

------
https://chatgpt.com/codex/tasks/task_e_68963ba4579c8326bcb42684cb7ca84a