### PR TITLE
Scope data caches to authenticated users

### DIFF
--- a/InSite/Core/Settings/SettingsViewModel.swift
+++ b/InSite/Core/Settings/SettingsViewModel.swift
@@ -7,6 +7,7 @@
 
 import Foundation
 import SwiftUI
+import FirebaseAuth
 
 @MainActor
 final class SettingsViewModel: ObservableObject {
@@ -18,7 +19,11 @@ final class SettingsViewModel: ObservableObject {
         }
     }
     func logOut() throws {
+        let departingUid = Auth.auth().currentUser?.uid
         try AuthManager.shared.signOut()
+        ProfileDataStore().clearData(for: departingUid)
+        SiteChangeData.shared.clearData(for: departingUid)
+        DataManager.shared.handleLogout(for: departingUid)
     }
     
     func resetPassword() async throws {

--- a/InSite/InSiteUI/TherapySettings.swift
+++ b/InSite/InSiteUI/TherapySettings.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import FirebaseAuth
 
 //Hold down on long press
 
@@ -20,8 +21,18 @@ struct HourRange: Codable, Identifiable {
 }
 
 class ProfileDataStore {
-    private let profilesKey = "profilesData"
-    private let activeProfileKey = "activeProfileID"
+    private enum DefaultsKey {
+        static let profiles = "profilesData"
+        static let activeProfile = "activeProfileID"
+    }
+
+    private func key(for base: String, uid: String? = Auth.auth().currentUser?.uid) -> String {
+        guard let uid = uid, !uid.isEmpty else { return base }
+        return "\(base)_\(uid)"
+    }
+
+    private var profilesKey: String { key(for: DefaultsKey.profiles) }
+    private var activeProfileKey: String { key(for: DefaultsKey.activeProfile) }
 
     func saveProfiles(_ profiles: [DiabeticProfile]) {
         let encoder = JSONEncoder()
@@ -58,6 +69,14 @@ class ProfileDataStore {
 
     func clearActiveProfileID() {
         UserDefaults.standard.removeObject(forKey: activeProfileKey)
+    }
+
+    func clearData(for uid: String?) {
+        let defaults = UserDefaults.standard
+        let profilesKey = key(for: DefaultsKey.profiles, uid: uid)
+        let activeKey = key(for: DefaultsKey.activeProfile, uid: uid)
+        defaults.removeObject(forKey: profilesKey)
+        defaults.removeObject(forKey: activeKey)
     }
 }
 


### PR DESCRIPTION
## Summary
- key therapy profile defaults by authenticated user and add helpers to clear stored data when a user signs out
- scope site-change metadata to each user, refresh observable state on auth changes, and wipe values during logout
- refresh the health uploader whenever auth changes, guard sync/backfill operations when no user is present, and clear cached uploaders after logout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d17a107f748326b25516b5895b119d